### PR TITLE
cli-dns: switch from dep ensure to go mod

### DIFF
--- a/dockerfiles/dns.Dockerfile
+++ b/dockerfiles/dns.Dockerfile
@@ -25,13 +25,11 @@ ARG BASE=akamai/base
 FROM golang:alpine as builder
 
 RUN apk add --no-cache git upx \
-  # building requires Dep package manager
-  && wget -O - https://raw.githubusercontent.com/golang/dep/master/install.sh | sh \
   && go get -d github.com/akamai/cli-dns \
   && cd "${GOPATH}/src/github.com/akamai/cli-dns" \
-  && dep ensure \
+  && go mod vendor \
   # -ldflags="-s -w" strips debug information from the executable 
-  && go build -o /akamaiDns -ldflags="-s -w" \
+  && go build -mod vendor -o /akamaiDns -ldflags="-s -w" \
   # upx creates a self-extracting compressed executable
   && upx -3 -o/akamaiDns.upx /akamaiDns \
   # we need to include the cli.json file as well


### PR DESCRIPTION
fix build, broken by https://github.com/akamai/cli-dns/commit/c1f9afdd7e6ef35d69cb33551578f1d1c0908f6e

cli dns switched from dep ensure to go mod.

Build tested locally, both:

./scripts/build-chain.sh cli dns

./scripts/build-chain.sh adaptive-acceleration api-gateway appsec cloudlets cps dns edgeworkers firewall httpie image-manager property property-manager purge sandbox terraform terraform-cli visitor-prioritization shell