### PR TITLE
add cli-jsonnet (#32)

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ This project provides images in two flavors:
 | akamai/property-manager       | 64.3MB | [GitHub](https://github.com/akamai/cli-property-manager)                   |
 | akamai/onboard                | 99.7MB | [GitHub](https://github.com/akamai/cli-onboard)                            |
 | akamai/image-manager          | 46.7MB | [GitHub](https://github.com/akamai/cli-image-manager)                      |
+| akamai/jsonnet                | 48.5MB | [GitHub](https://github.com/akamai-contrib/cli-jsonnet)                    |
 | akamai/firewall               | 45.5MB | [GitHub](https://github.com/akamai/cli-firewall)                           |
 | akamai/eaa                    | 45.3MB | [GitHub](https://github.com/akamai/cli-eaa)                                |
 | akamai/edgeworkers            | 58.2MB | [GitHub](https://github.com/akamai/cli-edgeworkers)                        |

--- a/dockerfiles/jsonnet.Dockerfile
+++ b/dockerfiles/jsonnet.Dockerfile
@@ -1,0 +1,64 @@
+# Copyright 2020 Akamai Technologies
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#####################
+# BUILD ARGS
+#########
+
+ARG BASE=akamai/base
+
+#####################
+# JSONNET BUILDER
+#########
+
+# The jsonnet CLI depends on jsonnetfmt being available on the PATH
+# to prettyfy its output.
+# It also makes sense to include both jsonnet and jsonnetfmt in this
+# image since it is likely that the user will want to render the
+# templates, not just generate them.
+
+FROM golang:alpine as jsonnet
+
+RUN apk add --no-cache git upx \
+  && git clone https://github.com/google/go-jsonnet.git \
+  && cd go-jsonnet \
+  && go build -o /jsonnet -ldflags="-s -w" ./cmd/jsonnet \
+  && upx -3 -o/jsonnet.upx /jsonnet \
+  && go build -o /jsonnetfmt -ldflags="-s -w" ./cmd/jsonnetfmt \
+  && upx -3 -o/jsonnetfmt.upx /jsonnetfmt \
+  && chmod +x /jsonnet*
+
+#####################
+# FINAL
+#########
+
+FROM ${BASE}
+
+COPY --from=jsonnet /jsonnet.upx /usr/bin/jsonnet
+COPY --from=jsonnet /jsonnetfmt.upx /usr/bin/jsonnetfmt
+
+RUN mkdir -p /cli/.akamai-cli/src \
+  && apk add --no-cache python3 \
+  && apk add --no-cache --virtual dev git gcc python3-dev py3-setuptools libffi-dev musl-dev openssl-dev \
+  && git clone --depth 1 https://github.com/akamai-contrib/cli-jsonnet.git /cli/.akamai-cli/src/cli-jsonnet \
+  && pip3 install --upgrade pip setuptools \
+  && pip3 install -r /cli/.akamai-cli/src/cli-jsonnet/requirements.txt \
+  # Drop dev dependencies
+  && apk del dev \
+  # Drop created wheels
+  && rm -rf /root/.cache \
+  # Drop ~20MB by removing bytecode cache created by pip
+  && find / -name __pycache__ | xargs rm -rf \
+  # git dir not needed, drops a few hundred KB (just a few hundred, thanks to shallow clone)
+  && rm -rf /cli/.akamai-cli/src/cli-eaa/.git

--- a/dockerfiles/shell.Dockerfile
+++ b/dockerfiles/shell.Dockerfile
@@ -19,21 +19,6 @@
 ARG BASE=akamai/base
 
 #####################
-# JSONNET BUILDER
-#########
-
-FROM golang:alpine as jsonnet
-
-RUN apk add --no-cache git upx \
-  && git clone https://github.com/google/go-jsonnet.git \
-  && cd go-jsonnet \
-  && go build -o /jsonnet -ldflags="-s -w" ./cmd/jsonnet \
-  && upx -3 -o/jsonnet.upx /jsonnet \
-  && go build -o /jsonnetfmt -ldflags="-s -w" ./cmd/jsonnetfmt \
-  && upx -3 -o/jsonnetfmt.upx /jsonnetfmt \
-  && chmod +x /jsonnet*
-
-#####################
 # FINAL
 #########
 
@@ -43,9 +28,6 @@ FROM ${BASE}
 # familiar with bash than ash
 # libstdc++: required by jsonnet
 RUN apk add --no-cache bash jq git vim tree bind-tools libstdc++
-
-COPY --from=jsonnet /jsonnet.upx /usr/bin/jsonnet
-COPY --from=jsonnet /jsonnetfmt.upx /usr/bin/jsonnetfmt
 
 COPY files/motd /etc/motd
 COPY files/profile /etc/profile

--- a/test.bats
+++ b/test.bats
@@ -97,6 +97,11 @@
   [ "$status" -eq 0 ]
 }
 
+@test "cli: jsonnet is executable" {
+  run akamai jsonnet --help
+  [ "$status" -eq 0 ]
+}
+
 @test "cli: onboard is executable" {
   run akamai onboard --help
   [ "$status" -eq 0 ]

--- a/variants
+++ b/variants
@@ -36,6 +36,7 @@ cli eaa
 cli edgeworkers
 cli firewall
 cli image-manager
+cli jsonnet
 cli property-manager
 property-manager onboard
 cli property
@@ -51,4 +52,4 @@ base httpie
 base terraform
 
 # interactive variant with all the things, for experimentation.
-cli adaptive-acceleration api-gateway appsec cloudlets cps dns eaa edgeworkers firewall httpie image-manager property property-manager onboard purge sandbox terraform terraform-cli visitor-prioritization shell
+cli adaptive-acceleration api-gateway appsec cloudlets cps dns eaa edgeworkers firewall httpie image-manager jsonnet property property-manager onboard purge sandbox terraform terraform-cli visitor-prioritization shell


### PR DESCRIPTION
Also moved jsonnet/jsonnetfmt executables out of shell variant, it is
enough to inherit those from the akamai/jsonnet slim image.

Test:

`docker run akamai/jsonnet:dev akamai jsonnet --help`
`docker run akamai/shell:dev akamai jsonnet --help`