### PR TITLE
Fix/consistent runtime versions

### DIFF
--- a/dockerfiles/api-gateway.Dockerfile
+++ b/dockerfiles/api-gateway.Dockerfile
@@ -22,7 +22,7 @@ ARG BASE=akamai/base
 # BUILDER
 #########
 
-FROM golang:alpine as builder
+FROM golang:alpine3.11 as builder
 
 RUN apk add --no-cache git upx \
   # building requires Dep package manager

--- a/dockerfiles/appsec.Dockerfile
+++ b/dockerfiles/appsec.Dockerfile
@@ -22,7 +22,7 @@ ARG BASE=akamai/base
 # BUILDER
 #########
 
-FROM node:alpine as builder
+FROM node:12-alpine3.11 as builder
 
 RUN apk add --no-cache git npm \
   # install cli-property from git

--- a/dockerfiles/cli.Dockerfile
+++ b/dockerfiles/cli.Dockerfile
@@ -22,7 +22,7 @@ ARG BASE=akamai/base
 # BUILDER
 #########
 
-FROM golang:alpine as builder
+FROM golang:alpine3.11 as builder
 
 RUN apk add --no-cache git upx \
   && go get -d github.com/akamai/cli \

--- a/dockerfiles/dns.Dockerfile
+++ b/dockerfiles/dns.Dockerfile
@@ -22,7 +22,7 @@ ARG BASE=akamai/base
 # BUILDER
 #########
 
-FROM golang:alpine as builder
+FROM golang:alpine3.11 as builder
 
 RUN apk add --no-cache git upx \
   && go get -d github.com/akamai/cli-dns \

--- a/dockerfiles/edgeworkers.Dockerfile
+++ b/dockerfiles/edgeworkers.Dockerfile
@@ -22,7 +22,7 @@ ARG BASE=akamai/base
 # BUILDER
 #########
 
-FROM node:alpine as builder
+FROM node:12-alpine3.11 as builder
 
 RUN apk add --no-cache git npm \
   # install cli-edgeworkers from git

--- a/dockerfiles/jsonnet.Dockerfile
+++ b/dockerfiles/jsonnet.Dockerfile
@@ -28,7 +28,7 @@ ARG BASE=akamai/base
 # image since it is likely that the user will want to render the
 # templates, not just generate them.
 
-FROM golang:alpine3.11 as builder
+FROM golang:alpine3.11 as jsonnet
 
 RUN apk add --no-cache git upx \
   && git clone https://github.com/google/go-jsonnet.git \

--- a/dockerfiles/jsonnet.Dockerfile
+++ b/dockerfiles/jsonnet.Dockerfile
@@ -28,7 +28,7 @@ ARG BASE=akamai/base
 # image since it is likely that the user will want to render the
 # templates, not just generate them.
 
-FROM golang:alpine as jsonnet
+FROM golang:alpine3.11 as builder
 
 RUN apk add --no-cache git upx \
   && git clone https://github.com/google/go-jsonnet.git \

--- a/dockerfiles/property-manager.Dockerfile
+++ b/dockerfiles/property-manager.Dockerfile
@@ -22,7 +22,7 @@ ARG BASE=akamai/base
 # BUILDER
 #########
 
-FROM node:alpine as builder
+FROM node:12-alpine3.11 as builder
 
 RUN apk add --no-cache git npm \
   # install cli-property-manager from git

--- a/dockerfiles/property.Dockerfile
+++ b/dockerfiles/property.Dockerfile
@@ -22,7 +22,7 @@ ARG BASE=akamai/base
 # BUILDER
 #########
 
-FROM node:alpine as builder
+FROM node:12-alpine3.11 as builder
 
 RUN apk add --no-cache git npm \
   # install cli-property from git

--- a/dockerfiles/purge.Dockerfile
+++ b/dockerfiles/purge.Dockerfile
@@ -22,7 +22,7 @@ ARG BASE=akamai/base
 # BUILDER
 #########
 
-FROM golang:alpine as builder
+FROM golang:alpine3.11 as builder
 
 RUN apk add --no-cache git upx \
   # building requires Dep package manager

--- a/dockerfiles/sandbox.Dockerfile
+++ b/dockerfiles/sandbox.Dockerfile
@@ -22,7 +22,7 @@ ARG BASE=akamai/base
 # BUILDER
 #########
 
-FROM node:alpine as builder
+FROM node:12-alpine3.11 as builder
 
 # sandbox originally binds to 127.0.0.1 which doesn't work with Docker's port mapping
 # the patch changes the ip to 0.0.0.0

--- a/dockerfiles/terraform-cli.Dockerfile
+++ b/dockerfiles/terraform-cli.Dockerfile
@@ -22,7 +22,7 @@ ARG BASE=akamai/base
 # BUILDER
 #########
 
-FROM golang:alpine as builder
+FROM golang:alpine3.11 as builder
 
 RUN apk add --no-cache git upx \
   && go get -d github.com/akamai/cli-terraform \

--- a/dockerfiles/terraform.Dockerfile
+++ b/dockerfiles/terraform.Dockerfile
@@ -22,7 +22,7 @@ ARG BASE=akamai/base
 # BUILDER
 #########
 
-FROM alpine as builder
+FROM alpine:3.11 as builder
 ARG TERRAFORM_VERSION=0.12.20
 ARG TERRAFORM_SHA256SUM=46bd906f8cb9bbb871905ecb23ae7344af8017d214d735fbb6d6c8e0feb20ff3
 


### PR DESCRIPTION
Variants don't declare alpine and runtime (nodejs, golang) versions explicitly. As a result we have no control what exact versions are used which may cause build errors. This change sets versions explicitly.