### PR TITLE
feat: implement semver and changelog (#33)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,11 +36,12 @@ language: minimal
 services:
   - docker
 
-# We only build master & dev
+# We only build master, dev and semver tags
 branches:
   only:
     - master
     - dev
+    - /^v\d+\.\d+\.\d+$/
 
 script:
   - ./scripts/ci.sh

--- a/scripts/bump.sh
+++ b/scripts/bump.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+
+# Copyright 2020 Akamai Technologies
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Fail fast
+set -e
+
+EDITOR=${EDITOR:-vim}
+SEMVER='v?([0-9]+)\.([0-9]+)\.([0-9]+)'
+TEMPDIR=$(mktemp -d)
+
+[ -z "$TEMPDIR" ] || trap "echo -n 'cleaning up, deleting temp dir: '; rm -rv $TEMPDIR" EXIT
+
+die() {
+  local excode=$1; shift;
+  1>&2 echo "$0: $@"
+  exit $excode
+}
+
+# previous_tag <REF?>
+#   outputs the latest annotated tag matching v*.*.* reachable from
+#   the ref provided as the first argument
+previous_tag() {
+  local from_ref=${1:-HEAD}
+  git describe --abbrev=0 --match='v*.*.*' $from_ref 2>/dev/null
+}
+
+# parse_version [VERSION] [VARNAME] [VARNAME] [VARNAME]
+#   parses VERSION and assigns the major, minor and patch component to
+#   each extra argument successively.
+parse_version() {
+  local expr=$(echo -n $1 | sed -E "s#$SEMVER#$2=\1 $3=\2 $4=\3#")
+  eval $expr
+}
+
+# increment_version [VERSION] major|minor|patch
+#   outputs VERSION, incremented according to (simplified) semver rules
+#   based on the second argument
+increment_version() {
+  parse_version $1 major minor patch
+  eval $2=$(($2+1))
+  case $2 in
+    major) minor=0; patch=0;;
+    minor) patch=0;;
+  esac
+  echo v$major.$minor.$patch
+}
+
+# version_changelog [VERSION]
+#   outputs the changelog for a VERSION
+version_changelog() {
+  local version=${1:-HEAD}
+
+  local previous_version=$(previous_tag $version^)
+  local range="${previous_version}..${version}"
+  if [ -z "${previous_version}" ];
+  then
+    range="${version}"
+  fi
+
+  git log --no-merges --oneline --pretty=tformat:"* %s - %an (%h)" --grep nochangelog --invert-grep $range
+}
+
+[[ $1 =~ major|minor|patch ]] || die 1 "usage: $0 major|minor|patch"
+[[ $(git rev-parse --abbrev-ref HEAD) == master ]] || die 2 "should only run on master branch"
+[[ -t 1 ]] || die 3 "stdout is not a terminal, this script should only be run interactively"
+
+previous_version=$(previous_tag || echo "v0.0.0")
+next_version=$(increment_version $previous_version $1)
+
+next_changelog=$TEMPDIR/CHANGELOG.md
+
+
+version_changelog > $next_changelog
+$EDITOR $next_changelog
+
+(
+  echo -e "# CHANGELOG\n\n"
+  echo -e "## $next_version ($(date -u +%Y-%m-%d))\n"
+  cat $next_changelog
+  echo
+
+  git for-each-ref --sort=-taggerdate --format="%(refname:short) %(taggerdate:short)" refs/tags/v*.*.* |
+    while read version version_date;
+    do
+      echo -e "## $version ($version_date)\n"
+      git tag -l --format="%(contents)" $version
+      echo
+    done
+) > CHANGELOG.md
+
+git add CHANGELOG.md
+git commit -m "chore: update changelog (nochangelog)"
+git tag -a -m "$(cat $next_changelog)" $next_version
+
+die 0 'success! next step, run git push --follow-tags'


### PR DESCRIPTION
Added scripts/bump.sh to handle version increments, changelog generation and tagging.

I would like to merge this directly into master, since it cannot be tested on any other branch.

The release management process will be:

* development happens as usual on dev/feature branches
* once the PR is merged to master, the merger will pull the changes to their local repository and run one of

```
./scripts/bump.sh major # for breaking changes
./scripts/bump.sh minor # for backwards-compatible enhancements
./scripts/bump.sh patch # for fixes
```

Followed by:

```
git push --follow-tags # to push the updated changelog and the release tag
```

This will trigger a build for the tag.

The bump.sh script performs the following steps:

* increments the version
* generates the changelog from the commit history since the previous version
* allows the merger to edit the changelog (the intent is to allow cleaning up, adding an annotation to summarize the release etc...)
* assembles the complete changelog from the current version changelog and previous version changelogs into CHANGELOG.md
* commits the CHANGELOG.md file
* creates an annotated tag with the current version changelog as the tag annotation