### PR TITLE
fix: update go package builds to satisfy golang 1.16

### DIFF
--- a/dockerfiles/cli.Dockerfile
+++ b/dockerfiles/cli.Dockerfile
@@ -25,9 +25,9 @@ ARG BASE=akamai/base
 FROM golang:alpine3.12 as builder
 
 RUN apk add --no-cache git upx \
-  && go get -d github.com/akamai/cli \
-  && cd $GOPATH/src/github.com/akamai/cli \
-  && go mod init \
+  && git clone --depth=1 https://github.com/akamai/cli \
+  && cd cli \
+  && go mod init github.com/akamai/cli \
   && go mod tidy \
   # -ldflags="-s -w" strips debug information from the executable 
   && go build -o /akamai -ldflags="-s -w" \

--- a/dockerfiles/dns.Dockerfile
+++ b/dockerfiles/dns.Dockerfile
@@ -25,15 +25,15 @@ ARG BASE=akamai/base
 FROM golang:alpine3.12 as builder
 
 RUN apk add --no-cache git upx \
-  && go get -d github.com/akamai/cli-dns \
-  && cd "${GOPATH}/src/github.com/akamai/cli-dns" \
+  && git clone --depth=1 https://github.com/akamai/cli-dns \
+  && cd cli-dns \
   && go mod vendor \
   # -ldflags="-s -w" strips debug information from the executable 
   && go build -mod vendor -o /akamaiDns -ldflags="-s -w" \
   # upx creates a self-extracting compressed executable
   && upx -3 -o/akamaiDns.upx /akamaiDns \
   # we need to include the cli.json file as well
-  && cp "${GOPATH}/src/github.com/akamai/cli-dns/cli.json" /cli.json \
+  && cp cli.json /cli.json \
   # git dir not needed, drops a few hundred KB (just a few hundred, thanks to shallow clone)
   && rm -rf /cli/.akamai-cli/src/cli-dns/.git
 

--- a/dockerfiles/purge.Dockerfile
+++ b/dockerfiles/purge.Dockerfile
@@ -25,17 +25,16 @@ ARG BASE=akamai/base
 FROM golang:alpine3.12 as builder
 
 RUN apk add --no-cache git upx \
-  # building requires Dep package manager
-  && wget -O - https://raw.githubusercontent.com/golang/dep/master/install.sh | sh \
-  && go get -d github.com/akamai/cli-purge \
-  && cd "${GOPATH}/src/github.com/akamai/cli-purge" \
-  && dep ensure \
+  && git clone --depth=1 https://github.com/akamai/cli-purge \
+  && cd cli-purge \
+  && go mod init github.com/akamai/cli-purge \
+  && go mod vendor \
   # -ldflags="-s -w" strips debug information from the executable 
   && go build -o /akamai-purge -ldflags="-s -w" \
   # upx creates a self-extracting compressed executable
   && upx -3 -o/akamai-purge.upx /akamai-purge \
   # we need to include the cli.json file as well
-  && cp "${GOPATH}/src/github.com/akamai/cli-purge/cli.json" /cli.json
+  && cp cli.json /cli.json
 
 #####################
 # FINAL

--- a/dockerfiles/terraform-cli.Dockerfile
+++ b/dockerfiles/terraform-cli.Dockerfile
@@ -25,14 +25,15 @@ ARG BASE=akamai/base
 FROM golang:alpine3.12 as builder
 
 RUN apk add --no-cache git upx \
-  && go get -d github.com/akamai/cli-terraform \
-  && cd "${GOPATH}/src/github.com/akamai/cli-terraform" \
+  && git clone --depth=1 https://github.com/akamai/cli-terraform \
+  && cd cli-terraform \
+  && go mod tidy \
   # -ldflags="-s -w" strips debug information from the executable 
   && go build -o /akamaiTerraform -ldflags="-s -w" \
   # upx creates a self-extracting compressed executable
   && upx -3 -o/akamaiTerraform.upx /akamaiTerraform \
   # we need to include the cli.json file as well
-  && cp "${GOPATH}/src/github.com/akamai/cli-terraform/cli.json" /cli.json \
+  && cp cli.json /cli.json \
   # git dir not needed, drops a few hundred KB (just a few hundred, thanks to shallow clone)
   && rm -rf /cli/.akamai-cli/src/cli-akamaiTerraform/.git
 

--- a/scripts/docker-login.sh
+++ b/scripts/docker-login.sh
@@ -25,10 +25,13 @@ set -e
 source ./scripts/env.sh
 
 #####################
-# MAIN
+# LOGIN
+#
+# We need to login before we build in order to increase the quota on docker pull
+# operations enforced on anonymous builds.
 #########
 
-./scripts/docker-login.sh
-./scripts/build-all.sh
-./scripts/test.sh
-./scripts/push-all.sh
+export DOCKER_USERNAME="${DOCKER_USERNAME:?DOCKER_USERNAME must be set}"
+export DOCKER_PASSWORD="${DOCKER_PASSWORD:?DOCKER_PASSWORD must be set}"
+echo "${DOCKER_PASSWORD}" |
+  docker login -u "${DOCKER_USERNAME}" --password-stdin ${DOCKER_REGISTRY}

--- a/scripts/push-all.sh
+++ b/scripts/push-all.sh
@@ -26,8 +26,6 @@ source ./scripts/env.sh
 
 # Required arguments
 export BUILD_NUMBER="${BUILD_NUMBER:?BUILD_NUMBER must be set}"
-export DOCKER_USERNAME="${DOCKER_USERNAME:?DOCKER_USERNAME must be set}"
-export DOCKER_PASSWORD="${DOCKER_PASSWORD:?DOCKER_PASSWORD must be set}"
 
 # Print all image:tag combinations created by the current build
 # using the build-number label, and excluding dangling images
@@ -42,10 +40,13 @@ current_build_tags() {
 
 #####################
 # LOGIN
+#
+# When called by CI, this is already done as part of the ci.sh build.
+# Logic is preserved here simply so push-all.sh can be called independently
+# if needed.
 #########
 
-echo "${DOCKER_PASSWORD}" |
-  docker login -u "${DOCKER_USERNAME}" --password-stdin ${DOCKER_REGISTRY}
+./scripts/docker-login.sh
 
 #####################
 # PUSH


### PR DESCRIPTION
Go 1.16 enables modules by default. We now git clone packages and

* if a go.mod file is not provided by that module, we run go mod init
* depending on the module, we run go mod tidy or go mod vendor

Ideally, we'd detect the case appropriately but unsure how to do this
at this point.

Additionally, this PR includes a change to docker login before building these images in an attempt to lift our docker pull quota restrictions.

Merged into dev already, here is the travis build: https://travis-ci.com/github/akamai/akamai-docker/builds/217525501

@javiergarza @akamaimike fyi, but not requiring your review for this PR