### PR TITLE
fix 404 for akamai/terraform-cli href

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ This project provides images in two flavors:
 |-------------------------------|--------|----------------------------------------------------------------------------|
 | akamai/shell                  | 403MB  | [GitHub](https://github.com/akamai/akamai-docker)                          |
 | akamai/terraform              | 48.4MB | [GitHub](https://github.com/terraform-providers/terraform-provider-akamai) |
-| akamai/terraform-cli          | 14.7MB | [GitHub](https://github.com/terraform-providers/cli-terraform)             |
+| akamai/terraform-cli          | 14.7MB | [GitHub](https://github.com/akamai/cli-terraform)             |
 | akamai/httpie                 | 45.2MB | [GitHub](https://github.com/akamai/httpie-edgegrid)                        |
 | akamai/visitor-prioritization | 45.1MB | [GitHub](https://github.com/akamai/cli-visitor-prioritization)             |
 | akamai/sandbox                | 158MB  | [GitHub](https://github.com/akamai/cli-sandbox)                            |


### PR DESCRIPTION
fix 404 for akamai/terraform-cli href