### PR TITLE
all-access /cli and /workdir to avoid jenkins perm issues

### DIFF
--- a/dockerfiles/adaptive-acceleration.Dockerfile
+++ b/dockerfiles/adaptive-acceleration.Dockerfile
@@ -36,7 +36,7 @@ RUN mkdir -p /cli/.akamai-cli/src \
   # Drop dev dependencies
   && apk del dev \
   # Drop created wheels
-  && rm -rf /root/.cache \
+  && rm -rf /workdir/.cache \
   # Drop ~20MB by removing bytecode cache created by pip
   && find / -name __pycache__ | xargs rm -rf \
   # git dir not needed, drops a few hundred KB (just a few hundred, thanks to shallow clone)

--- a/dockerfiles/base.Dockerfile
+++ b/dockerfiles/base.Dockerfile
@@ -26,4 +26,9 @@ FROM ${BASE}
 
 ENV CRYPTOGRAPHY_DONT_BUILD_RUST=1
 
-WORKDIR /root
+# Avoid permission issues by working outside of /root in an a+rwx dir.
+# (WORKDIR implictly creates as the current user, root)
+WORKDIR /workdir
+RUN chmod 0777 .
+# Declare as a volume AFTER creating it, otherwise the chmod does not work
+VOLUME /workdir

--- a/dockerfiles/cli.Dockerfile
+++ b/dockerfiles/cli.Dockerfile
@@ -55,3 +55,5 @@ RUN mkdir -p $AKAMAI_CLI_HOME/.akamai-cli ${AKAMAI_CLI_CACHE_PATH}
 COPY --from=builder /akamai.upx /bin/akamai
 
 ADD files/akamai-cli-config ${AKAMAI_CLI_HOME}/.akamai-cli/config
+
+RUN chmod -R a+rwx ${AKAMAI_CLI_HOME}

--- a/dockerfiles/cloudlets.Dockerfile
+++ b/dockerfiles/cloudlets.Dockerfile
@@ -33,7 +33,7 @@ RUN mkdir -p /cli/.akamai-cli/src \
   # Drop dev dependencies
   && apk del dev \
   # Drop created wheels
-  && rm -rf /root/.cache \
+  && rm -rf /workdir/.cache \
   # Drop ~20MB by removing bytecode cache created by pip
   && find / -name __pycache__ | xargs rm -rf \
   # git dir not needed, drops a few hundred KB (just a few hundred, thanks to shallow clone)

--- a/dockerfiles/cps.Dockerfile
+++ b/dockerfiles/cps.Dockerfile
@@ -33,7 +33,7 @@ RUN mkdir -p /cli/.akamai-cli/src \
   # Drop dev dependencies
   && apk del dev \
   # Drop created wheels
-  && rm -rf /root/.cache \
+  && rm -rf /workdir/.cache \
   # Drop ~20MB by removing bytecode cache created by pip
   && find / -name __pycache__ | xargs rm -rf \
   # git dir not needed, drops a few hundred KB (just a few hundred, thanks to shallow clone)

--- a/dockerfiles/eaa.Dockerfile
+++ b/dockerfiles/eaa.Dockerfile
@@ -33,7 +33,7 @@ RUN mkdir -p /cli/.akamai-cli/src \
   # Drop dev dependencies
   && apk del dev \
   # Drop created wheels
-  && rm -rf /root/.cache \
+  && rm -rf /workdir/.cache \
   # Drop ~20MB by removing bytecode cache created by pip
   && find / -name __pycache__ | xargs rm -rf \
   # git dir not needed, drops a few hundred KB (just a few hundred, thanks to shallow clone)

--- a/dockerfiles/etp.Dockerfile
+++ b/dockerfiles/etp.Dockerfile
@@ -33,7 +33,7 @@ RUN mkdir -p /cli/.akamai-cli/src \
   # Drop dev dependencies
   && apk del dev \
   # Drop created wheels
-  && rm -rf /root/.cache \
+  && rm -rf /workdir/.cache \
   # Drop ~20MB by removing bytecode cache created by pip
   && find / -name __pycache__ | xargs rm -rf \
   # git dir not needed, drops a few hundred KB (just a few hundred, thanks to shallow clone)

--- a/dockerfiles/firewall.Dockerfile
+++ b/dockerfiles/firewall.Dockerfile
@@ -33,7 +33,7 @@ RUN mkdir -p /cli/.akamai-cli/src \
   # Drop dev dependencies
   && apk del dev \
   # Drop created wheels
-  && rm -rf /root/.cache \
+  && rm -rf /workdir/.cache \
   # Drop ~20MB by removing bytecode cache created by pip
   && find / -name __pycache__ | xargs rm -rf \
   # git dir not needed, drops a few hundred KB (just a few hundred, thanks to shallow clone)

--- a/dockerfiles/httpie.Dockerfile
+++ b/dockerfiles/httpie.Dockerfile
@@ -32,8 +32,8 @@ RUN apk add --no-cache python3 py3-pip py3-setuptools \
   # Drop dev dependencies
   && apk del dev \
   # Drop created wheels
-  && rm -rf /root/.cache \
+  && rm -rf /workdir/.cache \
   # Drop ~20MB by removing bytecode cache created by pip
   && find / -name __pycache__ | xargs rm -rf
 
-ADD files/httpie-config.json /root/.httpie/config.json
+ADD files/httpie-config.json /workdir/.httpie/config.json

--- a/dockerfiles/image-manager.Dockerfile
+++ b/dockerfiles/image-manager.Dockerfile
@@ -36,7 +36,7 @@ RUN mkdir -p /cli/.akamai-cli/src \
   # Drop dev dependencies
   && apk del dev \
   # Drop created wheels
-  && rm -rf /root/.cache \
+  && rm -rf /workdir/.cache \
   # Drop ~20MB by removing bytecode cache created by pip
   && find / -name __pycache__ | xargs rm -rf \
   # git dir not needed, drops a few hundred KB (just a few hundred, thanks to shallow clone)

--- a/dockerfiles/jsonnet.Dockerfile
+++ b/dockerfiles/jsonnet.Dockerfile
@@ -61,7 +61,7 @@ RUN mkdir -p /cli/.akamai-cli/src \
   # Drop dev dependencies
   && apk del dev \
   # Drop created wheels
-  && rm -rf /root/.cache \
+  && rm -rf /workdir/.cache \
   # Drop ~20MB by removing bytecode cache created by pip
   && find / -name __pycache__ | xargs rm -rf \
   # git dir not needed, drops a few hundred KB (just a few hundred, thanks to shallow clone)

--- a/dockerfiles/onboard.Dockerfile
+++ b/dockerfiles/onboard.Dockerfile
@@ -33,7 +33,7 @@ RUN mkdir -p /cli/.akamai-cli/src \
   # Drop dev dependencies
   && apk del dev \
   # Drop created wheels
-  && rm -rf /root/.cache \
+  && rm -rf /workdir/.cache \
   # Drop ~20MB by removing bytecode cache created by pip
   && find / -name __pycache__ | xargs rm -rf \
   # git dir not needed, drops a few hundred KB (just a few hundred, thanks to shallow clone)

--- a/dockerfiles/visitor-prioritization.Dockerfile
+++ b/dockerfiles/visitor-prioritization.Dockerfile
@@ -33,7 +33,7 @@ RUN mkdir -p /cli/.akamai-cli/src \
   # Drop dev dependencies
   && apk del dev \
   # Drop created wheels
-  && rm -rf /root/.cache \
+  && rm -rf /workdir/.cache \
   # Drop ~20MB by removing bytecode cache created by pip
   && find / -name __pycache__ | xargs rm -rf \
   # git dir not needed, drops a few hundred KB (just a few hundred, thanks to shallow clone)


### PR DESCRIPTION
This is on `dev` and can be tested using `xyz:dev` for affected variants