### PR TITLE
DXE-2170 Upgrade akamai terraform provider to v3.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v2.9.0 (2023-02-02)
+
+* DXE-2170 Upgrade akamai terraform provider to v3.3.0 - Michal Wojcik (97d48b5) 
+
 ## v2.8.1 (2022-12-19)
 
 * DXE-1948 Upgrade akamai terraform provider to v3.2.1 - Mateusz Jakubiec (b8f4d30) 

--- a/dockerfiles/cli.Dockerfile
+++ b/dockerfiles/cli.Dockerfile
@@ -22,7 +22,7 @@ ARG BASE=akamai/base
 # BUILDER
 #########
 
-FROM golang:alpine3.13 as builder
+FROM golang:alpine3.17 as builder
 
 ARG CLI_REPOSITORY_URL=https://github.com/akamai/cli
 

--- a/files/terraform.tf
+++ b/files/terraform.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source = "akamai/akamai"
-      version = "3.2.1"
+      version = "3.3.0"
     }
 
     null = {


### PR DESCRIPTION
## v2.9.0 (2023-02-02)

* DXE-2170 Upgrade akamai terraform provider to v3.3.0