### PR TITLE
DXE-2945 Release/v2.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # CHANGELOG
 
-## v2.16.0 (2023-xx-xx)
+## v2.16.0 (2023-09-01)
 
 * DXE-2918 Add image akamai/test-center and include test-center cli in akamai/shell - Michal Wojcik
+* DXE-2945 Upgrade akamai terraform provider to v5.2.0 - Tatiana Slonimskaia
 
 ## v2.15.0 (2023-08-08)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v2.16.0 (2023-xx-xx)
+
+* DXE-2918 Add image akamai/test-center and include test-center cli in akamai/shell - Michal Wojcik
+
 ## v2.15.0 (2023-08-08)
 
 * DXE-2871 Upgrade akamai terraform provider to v5.1.0 - Dawid Dzhafarov (88800bf)

--- a/README.md
+++ b/README.md
@@ -47,29 +47,32 @@ This project provides images in two flavors:
 
 ## Variants
 
-| REPOSITORY                    | SIZE   | DOCS                                                                       |
-|-------------------------------|--------|----------------------------------------------------------------------------|
-| akamai/shell                  | 403MB  | [GitHub](https://github.com/akamai/akamai-docker)                          |
-| akamai/terraform              | 48.4MB | [GitHub](https://github.com/terraform-providers/terraform-provider-akamai) |
-| akamai/terraform-cli          | 14.7MB | [GitHub](https://github.com/akamai/cli-terraform)             |
-| akamai/httpie                 | 45.2MB | [GitHub](https://github.com/akamai/httpie-edgegrid)                        |
-| akamai/sandbox                | 158MB  | [GitHub](https://github.com/akamai/cli-sandbox)                            |
-| akamai/purge                  | 14.1MB | [GitHub](https://github.com/akamai/cli-purge)                              |
-| akamai/property-manager       | 64.3MB | [GitHub](https://github.com/akamai/cli-property-manager)                   |
-| akamai/onboard                | 99.7MB | [GitHub](https://github.com/akamai/cli-onboard)                            |
-| akamai/image-manager          | 46.7MB | [GitHub](https://github.com/akamai/cli-image-manager)                      |
-| akamai/jsonnet                | 48.5MB | [GitHub](https://github.com/akamai-contrib/cli-jsonnet)                    |
-| akamai/firewall               | 45.5MB | [GitHub](https://github.com/akamai/cli-firewall)                           |
-| akamai/eaa                    | 45.3MB | [GitHub](https://github.com/akamai/cli-eaa)                                |
-| akamai/edgeworkers            | 58.2MB | [GitHub](https://github.com/akamai/cli-edgeworkers)                        |
-| akamai/dns                    | 14.2MB | [GitHub](https://github.com/akamai/cli-dns)                                |
-| akamai/cps                    | 46.2MB | [GitHub](https://github.com/akamai/cli-cps)                                |
-| akamai/cloudlets              | 45.5MB | [GitHub](https://github.com/akamai/cli-cloudlets)                          |
-| akamai/appsec                 | 56.6MB | [GitHub](https://github.com/akamai/cli-appsec)                             |
-| akamai/api-gateway            | 21.1MB | [GitHub](https://github.com/akamai/cli-api-gateway)                        |
-| akamai/adaptive-acceleration  | 45.2MB | [GitHub](https://github.com/akamai/cli-adaptive-acceleration)              |
-| akamai/etp                    | 49.1MB | [GitHub](https://github.com/akamai/cli-etp)                                | 
-| akamai/gtm                    | 14.2MB | [GitHub](https://github.com/akamai/cli-gtm)
+| REPOSITORY                   | DOCS                                                                       |
+|------------------------------|----------------------------------------------------------------------------|
+| akamai/shell                 | [GitHub](https://github.com/akamai/akamai-docker)                          |
+| akamai/terraform             | [GitHub](https://github.com/terraform-providers/terraform-provider-akamai) |
+| akamai/terraform-cli         | [GitHub](https://github.com/akamai/cli-terraform)                          |
+| akamai/httpie                | [GitHub](https://github.com/akamai/httpie-edgegrid)                        |
+| akamai/test-center           | [GitHub](https://github.com/akamai/cli-test-center)                        |
+| akamai/sandbox               | [GitHub](https://github.com/akamai/cli-sandbox)                            |
+| akamai/purge                 | [GitHub](https://github.com/akamai/cli-purge)                              |
+| akamai/property-manager      | [GitHub](https://github.com/akamai/cli-property-manager)                   |
+| akamai/onboard               | [GitHub](https://github.com/akamai/cli-onboard)                            |
+| akamai/image-manager         | [GitHub](https://github.com/akamai/cli-image-manager)                      |
+| akamai/jsonnet               | [GitHub](https://github.com/akamai-contrib/cli-jsonnet)                    |
+| akamai/firewall              | [GitHub](https://github.com/akamai/cli-firewall)                           |
+| akamai/eaa                   | [GitHub](https://github.com/akamai/cli-eaa)                                |
+| akamai/edgeworkers           | [GitHub](https://github.com/akamai/cli-edgeworkers)                        |
+| akamai/dns                   | [GitHub](https://github.com/akamai/cli-dns)                                |
+| akamai/cps                   | [GitHub](https://github.com/akamai/cli-cps)                                |
+| akamai/cloudlets             | [GitHub](https://github.com/akamai/cli-cloudlets)                          |
+| akamai/appsec                | [GitHub](https://github.com/akamai/cli-appsec)                             |
+| akamai/api-gateway           | [GitHub](https://github.com/akamai/cli-api-gateway)                        |
+| akamai/adaptive-acceleration | [GitHub](https://github.com/akamai/cli-adaptive-acceleration)              |
+| akamai/etp                   | [GitHub](https://github.com/akamai/cli-etp)                                | 
+| akamai/gtm                   | [GitHub](https://github.com/akamai/cli-gtm)                                |
+
+List of current docker images with their current sizes, can be funder in Dockerhub (https://hub.docker.com/u/akamai).
 
 All variants use an Alpine Linux base.
 

--- a/dockerfiles/test-center.Dockerfile
+++ b/dockerfiles/test-center.Dockerfile
@@ -1,0 +1,52 @@
+# Copyright 2023 Akamai Technologies
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#####################
+# BUILD ARGS
+#########
+
+ARG BASE=akamai/base
+
+#####################
+# BUILDER
+#########
+
+FROM golang:alpine3.17 as builder
+
+# this will only be used on architectures that upx doesn't use
+COPY files/upx-noop /usr/bin/upx
+RUN chmod +x /usr/bin/upx
+
+RUN apk add --no-cache $(apk search --no-cache | grep -q ^upx && echo -n upx) git \
+  && git clone --depth=1 https://github.com/akamai/cli-test-center.git \
+  && cd cli-test-center \
+  && go mod tidy \
+  # -ldflags="-s -w" strips debug information from the executable 
+  && go build -o /testCenter -ldflags="-s -w" \
+  # upx creates a self-extracting compressed executable
+  && upx -3 -o/testCenter.upx /testCenter \
+  # we need to include the cli.json file as well
+  && cp cli.json /cli.json \
+  # git dir not needed, drops a few hundred KB (just a few hundred, thanks to shallow clone)
+  && rm -rf /cli/.akamai-cli/src/cli-test-center/.git
+
+#####################
+# FINAL
+#########
+
+FROM $BASE
+
+RUN mkdir -p /cli/.akamai-cli/src/cli-test-center/bin
+COPY --from=builder /testCenter.upx /cli/.akamai-cli/src/cli-test-center/bin/akamai-test-center
+COPY --from=builder /cli.json /cli/.akamai-cli/src/cli-test-center/cli.json

--- a/files/terraform.tf
+++ b/files/terraform.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source = "akamai/akamai"
-      version = "5.1.0"
+      version = "5.2.0"
     }
 
     null = {

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -46,7 +46,7 @@ set -e
 apk add --no-cache git bash
 git clone https://github.com/bats-core/bats-core.git
 cd bats-core
-./install.sh /
+./install.sh /usr/local
 cd /
 bats /test.bats
 EOF

--- a/variants
+++ b/variants
@@ -44,6 +44,7 @@ cli sandbox
 cli terraform-cli
 cli etp
 cli gtm
+cli test-center
 
 # Non-Akamai CLI utilities
 # httpie + edgegrid
@@ -52,4 +53,4 @@ base httpie
 base terraform
 
 # interactive variant with all the things, for experimentation.
-cli adaptive-acceleration api-gateway appsec cloudlets cps dns eaa edgeworkers firewall httpie image-manager jsonnet property-manager onboard purge sandbox terraform terraform-cli etp gtm shell
+cli adaptive-acceleration api-gateway appsec cloudlets cps dns eaa edgeworkers firewall httpie image-manager jsonnet property-manager onboard purge sandbox terraform terraform-cli etp gtm test-center shell


### PR DESCRIPTION
## v2.16.0 (2023-09-01)

* DXE-2918 Add image akamai/test-center and include test-center cli in akamai/shell - Michal Wojcik
* DXE-2945 Upgrade akamai terraform provider to v5.2.0 - Tatiana Slonimskaia