### PR TITLE
DXE-3199 Release/v2.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v2.19.0 (2023-12-08)
+
+* DXE-3199 Upgrade akamai terraform provider to v5.5.0
+
 ## v2.18.0 (2023-11-02)
 
 * DXE-3185 Upgrade akamai terraform provider to v5.4.0 - Wojciech Zagrajczuk

--- a/files/terraform.tf
+++ b/files/terraform.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source = "akamai/akamai"
-      version = "5.4.0"
+      version = "5.5.0"
     }
 
     null = {


### PR DESCRIPTION
## v2.19.0 (2023-12-08)

* DXE-3199 Upgrade akamai terraform provider to v5.5.0