### PR TITLE
DXE-3947 Release/v2.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # CHANGELOG
 
-## vx.x.x (x-x-x)
+## v2.25.0 (2024-09-05)
 
 * DXE-4064 Change locally built images tags to `local-amd64` or `local-arm64`
+* DXE-3947 Upgrade akamai terraform provider to v6.4.0
 
 ## v2.24.0 (2024-07-17)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## vx.x.x (x-x-x)
+
+* DXE-4064 Change locally built images tags to `local-amd64` or `local-arm64`
+
 ## v2.24.0 (2024-07-17)
 
 * DXE-3869 Upgrade akamai terraform provider to v6.3.0

--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ You can find further usage examples on [docs/TUTORIAL.md](docs/TUTORIAL.md).
 
 ## License
 
-Copyright 2020 Akamai Technologies, Inc.
+Copyright © 2024 Akamai Technologies, Inc. All rights reserved.
 
 See [Apache License 2.0](LICENSE)
 

--- a/dockerfiles/adaptive-acceleration.Dockerfile
+++ b/dockerfiles/adaptive-acceleration.Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2020 Akamai Technologies
+# Copyright © 2024 Akamai Technologies, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/dockerfiles/api-gateway.Dockerfile
+++ b/dockerfiles/api-gateway.Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2020 Akamai Technologies
+# Copyright © 2024 Akamai Technologies, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/dockerfiles/appsec.Dockerfile
+++ b/dockerfiles/appsec.Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2020 Akamai Technologies
+# Copyright © 2024 Akamai Technologies, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/dockerfiles/base.Dockerfile
+++ b/dockerfiles/base.Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2020 Akamai Technologies
+# Copyright © 2024 Akamai Technologies, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/dockerfiles/cli.Dockerfile
+++ b/dockerfiles/cli.Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2020 Akamai Technologies
+# Copyright © 2024 Akamai Technologies, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/dockerfiles/cloudlets.Dockerfile
+++ b/dockerfiles/cloudlets.Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2020 Akamai Technologies
+# Copyright © 2024 Akamai Technologies, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/dockerfiles/cps.Dockerfile
+++ b/dockerfiles/cps.Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2020 Akamai Technologies
+# Copyright © 2024 Akamai Technologies, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/dockerfiles/dns.Dockerfile
+++ b/dockerfiles/dns.Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2020 Akamai Technologies
+# Copyright © 2024 Akamai Technologies, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/dockerfiles/eaa.Dockerfile
+++ b/dockerfiles/eaa.Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2020 Akamai Technologies
+# Copyright © 2024 Akamai Technologies, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/dockerfiles/edgeworkers.Dockerfile
+++ b/dockerfiles/edgeworkers.Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2020 Akamai Technologies
+# Copyright © 2024 Akamai Technologies, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/dockerfiles/etp.Dockerfile
+++ b/dockerfiles/etp.Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2020 Akamai Technologies
+# Copyright © 2024 Akamai Technologies, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/dockerfiles/firewall.Dockerfile
+++ b/dockerfiles/firewall.Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2020 Akamai Technologies
+# Copyright © 2024 Akamai Technologies, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/dockerfiles/gtm.Dockerfile
+++ b/dockerfiles/gtm.Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2020 Akamai Technologies
+# Copyright © 2024 Akamai Technologies, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/dockerfiles/httpie.Dockerfile
+++ b/dockerfiles/httpie.Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2020 Akamai Technologies
+# Copyright © 2024 Akamai Technologies, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/dockerfiles/image-manager.Dockerfile
+++ b/dockerfiles/image-manager.Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2020 Akamai Technologies
+# Copyright © 2024 Akamai Technologies, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/dockerfiles/jsonnet.Dockerfile
+++ b/dockerfiles/jsonnet.Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2020 Akamai Technologies
+# Copyright © 2024 Akamai Technologies, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/dockerfiles/onboard.Dockerfile
+++ b/dockerfiles/onboard.Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2020 Akamai Technologies
+# Copyright © 2024 Akamai Technologies, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/dockerfiles/property-manager.Dockerfile
+++ b/dockerfiles/property-manager.Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2020 Akamai Technologies
+# Copyright © 2024 Akamai Technologies, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/dockerfiles/purge.Dockerfile
+++ b/dockerfiles/purge.Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2020 Akamai Technologies
+# Copyright © 2024 Akamai Technologies, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/dockerfiles/sandbox.Dockerfile
+++ b/dockerfiles/sandbox.Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2020 Akamai Technologies
+# Copyright © 2024 Akamai Technologies, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/dockerfiles/shell.Dockerfile
+++ b/dockerfiles/shell.Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2020 Akamai Technologies
+# Copyright © 2024 Akamai Technologies, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/dockerfiles/terraform-cli.Dockerfile
+++ b/dockerfiles/terraform-cli.Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2020 Akamai Technologies
+# Copyright © 2024 Akamai Technologies, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/dockerfiles/terraform.Dockerfile
+++ b/dockerfiles/terraform.Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2020 Akamai Technologies
+# Copyright © 2024 Akamai Technologies, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/dockerfiles/test-center.Dockerfile
+++ b/dockerfiles/test-center.Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2023 Akamai Technologies
+# Copyright © 2024 Akamai Technologies, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -76,7 +76,8 @@ The variants are all built. In addition to `latest`, a timestamp tag is also cre
 
 ### Local builds
 
-Useful for local development, `build-all.sh` or `build-chain.sh` can be invoked directly.
+Useful for local development, `build-all.sh` or `build-chain.sh` can be invoked directly. Depending on the platform, the images
+are assigned `local-arm64` or `local-amd64` tags.
 
 Note that one cannot invoke `build-chain.sh base cli` without first invoking `build-chain.sh base`, because the first image in a chain is not implicitly built.
 
@@ -118,7 +119,7 @@ Setting `CLI_REPOSITORY_URL` will cause cli.Dockerfile to use `git://host.docker
 
 ## License
 
-Copyright 2020 Akamai Technologies, Inc.
+Copyright © 2024 Akamai Technologies, Inc. All rights reserved.
 
 See [Apache License 2.0](../LICENSE)
 

--- a/files/terraform.tf
+++ b/files/terraform.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source = "akamai/akamai"
-      version = "6.3.0"
+      version = "6.4.0"
     }
 
     null = {

--- a/scripts/build-all.sh
+++ b/scripts/build-all.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2020 Akamai Technologies
+# Copyright © 2024 Akamai Technologies, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/scripts/build-chain.sh
+++ b/scripts/build-chain.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2020 Akamai Technologies
+# Copyright © 2024 Akamai Technologies, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -55,12 +55,12 @@ build_img() {
 
   if [ "$#" == 2 ]; # $1=image, $2=Dockerfile
   then
-    docker build --platform linux/arm64 --force-rm -t $1:arm64 -f $2 ${DOCKER_BUILD_EXTRA_ARGS} "${labels[@]}" .
-    docker build --platform linux/amd64 --force-rm -t $1:amd64 -f $2 ${DOCKER_BUILD_EXTRA_ARGS} "${labels[@]}" .
+    docker build --platform linux/arm64 --force-rm -t $1:local-arm64 -f $2 ${DOCKER_BUILD_EXTRA_ARGS} "${labels[@]}" .
+    docker build --platform linux/amd64 --force-rm -t $1:local-amd64 -f $2 ${DOCKER_BUILD_EXTRA_ARGS} "${labels[@]}" .
   elif [ "$#" == 3 ]; # ..., $3=Base image
   then
-    docker build --platform linux/arm64 --force-rm -t $1:arm64 -f $2 ${DOCKER_BUILD_EXTRA_ARGS} "${labels[@]}" --build-arg BASE=$3:arm64 .
-    docker build --platform linux/amd64 --force-rm -t $1:amd64 -f $2 ${DOCKER_BUILD_EXTRA_ARGS} "${labels[@]}" --build-arg BASE=$3:amd64 .
+    docker build --platform linux/arm64 --force-rm -t $1:local-arm64 -f $2 ${DOCKER_BUILD_EXTRA_ARGS} "${labels[@]}" --build-arg BASE=$3:local-arm64 .
+    docker build --platform linux/amd64 --force-rm -t $1:local-amd64 -f $2 ${DOCKER_BUILD_EXTRA_ARGS} "${labels[@]}" --build-arg BASE=$3:local-amd64 .
   else
     echo "Unexpected number of arguments to build_img function: $#, failing"
     exit 1

--- a/scripts/bump.sh
+++ b/scripts/bump.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2020 Akamai Technologies
+# Copyright © 2024 Akamai Technologies, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2020 Akamai Technologies
+# Copyright © 2024 Akamai Technologies, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/scripts/docker-login.sh
+++ b/scripts/docker-login.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2020 Akamai Technologies
+# Copyright © 2024 Akamai Technologies, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -34,4 +34,4 @@ source ./scripts/env.sh
 export DOCKER_USERNAME="${DOCKER_USERNAME:?DOCKER_USERNAME must be set}"
 export DOCKER_PASSWORD="${DOCKER_PASSWORD:?DOCKER_PASSWORD must be set}"
 echo "${DOCKER_PASSWORD}" |
-  docker login -u "${DOCKER_USERNAME}" --password-stdin ${DOCKER_REGISTRY}
+  docker login -u "${DOCKER_USERNAME}" --password-stdin "${DOCKER_REGISTRY}"

--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2020 Akamai Technologies
+# Copyright © 2024 Akamai Technologies, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/scripts/push-all.sh
+++ b/scripts/push-all.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2020 Akamai Technologies
+# Copyright © 2024 Akamai Technologies, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -63,11 +63,11 @@ current_build_tags | grep -Ev "$DOCKER_REPOSITORY/(base|.*-chain)" |
     echo "$image"
     for tag in ${DOCKER_TAG};
     do
-      # retag images; adds build number to avoid race condition between builds
+      # re-tag images; adds build number to avoid race condition between builds
       ARMTAG="$BUILD_NUMBER-arm64"
       AMDTAG="$BUILD_NUMBER-amd64"
-      docker tag "$image:arm64" "$image:$ARMTAG"
-      docker tag "$image:amd64" "$image:$AMDTAG"
+      docker tag "$image:local-arm64" "$image:$ARMTAG"
+      docker tag "$image:local-amd64" "$image:$AMDTAG"
       # push temporary image tags
       docker push "$image:$ARMTAG"
       docker push "$image:$AMDTAG"
@@ -75,7 +75,7 @@ current_build_tags | grep -Ev "$DOCKER_REPOSITORY/(base|.*-chain)" |
       docker manifest create "$image:$tag" --amend "$image:$ARMTAG" --amend "$image:$AMDTAG"
       docker manifest push "$image:$tag"
       # remove temporary tags
-      remove_tag "$image" $ARMTAG
-      remove_tag "$image" $AMDTAG
+      remove_tag "$image" "$ARMTAG"
+      remove_tag "$image" "$AMDTAG"
     done
   done

--- a/scripts/remove-tag.sh
+++ b/scripts/remove-tag.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2020 Akamai Technologies
+# Copyright © 2024 Akamai Technologies, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test.bats
+++ b/test.bats
@@ -34,12 +34,12 @@
   [ "$status" -eq 0 ]
 }
 
-# @test "cli: adaptive-acceleration is executable" {
-#  # A2 does not have a --help
-#  run akamai adaptive-acceleration
-#  [ "$status" -eq 1 ]
-#  [[ "$output" =~ "ERROR: missing adaptive-acceleration command." ]]
-# }
+@test "cli: adaptive-acceleration is executable" {
+  # A2 does not have a --help
+  run akamai adaptive-acceleration
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "ERROR: missing adaptive-acceleration command." ]]
+}
 
 @test "cli: api-gateway: api-gateway is executable" {
   run akamai api-gateway --help
@@ -97,10 +97,10 @@
   [ "$status" -eq 0 ]
 }
 
-# @test "cli: image-manager is executable" {
-#  run akamai image-manager --help
-#  [ "$status" -eq 0 ]
-# }
+@test "cli: image-manager is executable" {
+  run akamai image-manager --help
+  [ "$status" -eq 0 ]
+}
 
 @test "cli: jsonnet is executable" {
   run akamai jsonnet --help

--- a/test.bats
+++ b/test.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 
-# Copyright 2020 Akamai Technologies
+# Copyright © 2024 Akamai Technologies, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/variants
+++ b/variants
@@ -1,4 +1,4 @@
-# Copyright 2020 Akamai Technologies
+# Copyright © 2024 Akamai Technologies, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
## v2.25.0 (2024-09-05)

* DXE-4064 Change locally built images tags to `local-amd64` or `local-arm64`
* DXE-3947 Upgrade akamai terraform provider to v6.4.0