### PR TITLE
Release/v2.28.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v2.28.0 (2024-12-20)
+
+* Upgraded akamai terraform provider to v6.6.1
+
 ## v2.27.0 (2024-11-22)
 
 * Resolved problem with EdgeWorkers CLI hitting cert issues in akamai/shell Docker image

--- a/files/terraform.tf
+++ b/files/terraform.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source = "akamai/akamai"
-      version = "6.6.0"
+      version = "6.6.1"
     }
 
     null = {


### PR DESCRIPTION
## v2.28.0 (2024-12-20)

* Upgraded akamai terraform provider to v6.6.1