### PR TITLE
Release/v2.29.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # CHANGELOG
 
-## v2.29.0 (2025-x-x)
+## v2.29.0 (2025-02-07)
 
-* DXE-4198 Upgrade go version to `1.22.9` for `dns`,`cli`,`gtm`,`jsonnet`,`purge`,`terraform-cli`,`test-center`,`api-gateway`.
+* Upgraded akamai terraform provider to v7.0.0.
+* Upgraded Go version to `1.22.9` for `dns`,`cli`,`gtm`,`jsonnet`,`purge`,`terraform-cli`,`test-center` images.
 
 ## v2.28.0 (2024-12-20)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v2.28.0 (2025-x-x)
+
+* DXE-4198 Upgrade go version to `1.22.9` for `dns`,`cli`,`gtm`,`jsonnet`,`purge`,`terraform-cli`,`test-center`,`api-gateway`.
+
 ## v2.27.0 (2024-11-22)
 
 * Resolved problem with EdgeWorkers CLI hitting cert issues in akamai/shell Docker image

--- a/dockerfiles/api-gateway.Dockerfile
+++ b/dockerfiles/api-gateway.Dockerfile
@@ -22,7 +22,7 @@ ARG BASE=akamai/base
 # BUILDER
 #########
 
-FROM golang:1.22.9-alpine3.19 as builder
+FROM golang:1.21.12-alpine3.19 as builder
 
 # this will only be used on architectures that upx doesn't use
 COPY files/upx-noop /usr/bin/upx

--- a/dockerfiles/api-gateway.Dockerfile
+++ b/dockerfiles/api-gateway.Dockerfile
@@ -22,7 +22,7 @@ ARG BASE=akamai/base
 # BUILDER
 #########
 
-FROM golang:1.21.12-alpine3.19 as builder
+FROM golang:1.22.9-alpine3.19 as builder
 
 # this will only be used on architectures that upx doesn't use
 COPY files/upx-noop /usr/bin/upx

--- a/dockerfiles/cli.Dockerfile
+++ b/dockerfiles/cli.Dockerfile
@@ -22,7 +22,7 @@ ARG BASE=akamai/base
 # BUILDER
 #########
 
-FROM golang:1.21.12-alpine3.19 as builder
+FROM golang:1.22.9-alpine3.19 as builder
 
 ARG CLI_REPOSITORY_URL=https://github.com/akamai/cli
 

--- a/dockerfiles/dns.Dockerfile
+++ b/dockerfiles/dns.Dockerfile
@@ -22,7 +22,7 @@ ARG BASE=akamai/base
 # BUILDER
 #########
 
-FROM golang:1.21.12-alpine3.19 as builder
+FROM golang:1.22.9-alpine3.19 as builder
 
 # this will only be used on architectures that upx doesn't use
 COPY files/upx-noop /usr/bin/upx

--- a/dockerfiles/gtm.Dockerfile
+++ b/dockerfiles/gtm.Dockerfile
@@ -22,7 +22,7 @@ ARG BASE=akamai/base
 # BUILDER
 #########
 
-FROM golang:1.21.12-alpine3.19 as builder
+FROM golang:1.22.9-alpine3.19 as builder
 
 # this will only be used on architectures that upx doesn't use
 COPY files/upx-noop /usr/bin/upx

--- a/dockerfiles/httpie.Dockerfile
+++ b/dockerfiles/httpie.Dockerfile
@@ -32,7 +32,7 @@ RUN apk add --no-cache python3 py3-pip py3-setuptools \
   # Activate the virtual environment
   && . /venv/bin/activate \
   && pip install --upgrade pip setuptools \
-  && pip install  pip-system-certs httpie httpie-edgegrid \
+  && pip install httpie httpie-edgegrid \
   # Drop dev dependencies
   && apk del dev \
   # Drop created wheels

--- a/dockerfiles/jsonnet.Dockerfile
+++ b/dockerfiles/jsonnet.Dockerfile
@@ -28,7 +28,7 @@ ARG BASE=akamai/base
 # image since it is likely that the user will want to render the
 # templates, not just generate them.
 
-FROM golang:1.21.12-alpine3.19 as jsonnet
+FROM golang:1.22.9-alpine3.19 as jsonnet
 
 # this will only be used on architectures that upx doesn't use
 COPY files/upx-noop /usr/bin/upx

--- a/dockerfiles/purge.Dockerfile
+++ b/dockerfiles/purge.Dockerfile
@@ -22,7 +22,7 @@ ARG BASE=akamai/base
 # BUILDER
 #########
 
-FROM golang:1.21.12-alpine3.19 as builder
+FROM golang:1.22.9-alpine3.19 as builder
 
 # this will only be used on architectures that upx doesn't use
 COPY files/upx-noop /usr/bin/upx

--- a/dockerfiles/terraform-cli.Dockerfile
+++ b/dockerfiles/terraform-cli.Dockerfile
@@ -22,7 +22,7 @@ ARG BASE=akamai/base
 # BUILDER
 #########
 
-FROM golang:1.21.12-alpine3.19 as builder
+FROM golang:1.22.9-alpine3.19 as builder
 
 # this will only be used on architectures that upx doesn't use
 COPY files/upx-noop /usr/bin/upx

--- a/dockerfiles/test-center.Dockerfile
+++ b/dockerfiles/test-center.Dockerfile
@@ -22,7 +22,7 @@ ARG BASE=akamai/base
 # BUILDER
 #########
 
-FROM golang:1.21.12-alpine3.19 as builder
+FROM golang:1.22.9-alpine3.19 as builder
 
 # this will only be used on architectures that upx doesn't use
 COPY files/upx-noop /usr/bin/upx

--- a/files/terraform.tf
+++ b/files/terraform.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source = "akamai/akamai"
-      version = "6.6.1"
+      version = "7.0.0"
     }
 
     null = {


### PR DESCRIPTION
## v2.29.0 (2025-02-07)

* Upgraded akamai terraform provider to v7.0.0.
* Upgraded Go version to `1.22.9` for `dns`,`cli`,`gtm`,`jsonnet`,`purge`,`terraform-cli`,`test-center` images.
