### PR TITLE
Release/v2.30.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,14 @@
 # CHANGELOG
 
-## v2.X.X (X-X-X)
+## v2.30.0 (2025-04-08)
 
-* Upgraded Go version to `1.23.6` and alpine to `3.21` for `api-gateway`,dns`,`cli`,`gtm`,`jsonnet`,`purge`,`terraform-cli`,`test-center` images.
+* Upgraded akamai terraform provider to v7.1.0.
+* Upgraded Go version to `1.23.8` for `dns`, `cli`, `gtm`, `jsonnet`, `purge`, `terraform-cli`, and `test-center` images.
 
 ## v2.29.0 (2025-02-07)
 
 * Upgraded akamai terraform provider to v7.0.0.
-* Upgraded Go version to `1.22.9` for `dns`,`cli`,`gtm`,`jsonnet`,`purge`,`terraform-cli`,`test-center` images.
+* Upgraded Go version to `1.22.9` for `dns`, `cli`, `gtm`, `jsonnet`, `purge`, `terraform-cli`, and `test-center` images.
 
 ## v2.28.0 (2024-12-20)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v2.X.X (X-X-X)
+
+* Upgraded Go version to `1.23.6` and alpine to `3.21` for `api-gateway`,dns`,`cli`,`gtm`,`jsonnet`,`purge`,`terraform-cli`,`test-center` images.
+
 ## v2.29.0 (2025-02-07)
 
 * Upgraded akamai terraform provider to v7.0.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## v2.30.0 (2025-04-08)
 
 * Upgraded akamai terraform provider to v7.1.0.
-* Upgraded Go version to `1.23.8` for `dns`, `cli`, `gtm`, `jsonnet`, `purge`, `terraform-cli`, and `test-center` images.
+* Upgraded Go version to `1.23.8` and alpine to `3.21` for `dns`, `cli`, `gtm`, `jsonnet`, `purge`, `terraform-cli`, and `test-center` images.
 
 ## v2.29.0 (2025-02-07)
 

--- a/dockerfiles/api-gateway.Dockerfile
+++ b/dockerfiles/api-gateway.Dockerfile
@@ -22,7 +22,7 @@ ARG BASE=akamai/base
 # BUILDER
 #########
 
-FROM golang:1.22.9-alpine3.19 as builder
+FROM golang:1.21.12-alpine3.19 as builder
 
 # this will only be used on architectures that upx doesn't use
 COPY files/upx-noop /usr/bin/upx

--- a/dockerfiles/api-gateway.Dockerfile
+++ b/dockerfiles/api-gateway.Dockerfile
@@ -22,7 +22,7 @@ ARG BASE=akamai/base
 # BUILDER
 #########
 
-FROM golang:1.21.12-alpine3.19 as builder
+FROM golang:1.22.9-alpine3.19 as builder
 
 # this will only be used on architectures that upx doesn't use
 COPY files/upx-noop /usr/bin/upx

--- a/dockerfiles/api-gateway.Dockerfile
+++ b/dockerfiles/api-gateway.Dockerfile
@@ -22,6 +22,9 @@ ARG BASE=akamai/base
 # BUILDER
 #########
 
+# Do not upgrade Go version beyond 1.21 for api-gateway
+# as the project structure is outdated and may not be compatible.
+
 FROM golang:1.21.12-alpine3.19 as builder
 
 # this will only be used on architectures that upx doesn't use

--- a/dockerfiles/cli.Dockerfile
+++ b/dockerfiles/cli.Dockerfile
@@ -22,7 +22,7 @@ ARG BASE=akamai/base
 # BUILDER
 #########
 
-FROM golang:1.23.6-alpine3.21 as builder
+FROM golang:1.23.8-alpine3.21 as builder
 
 ARG CLI_REPOSITORY_URL=https://github.com/akamai/cli
 

--- a/dockerfiles/cli.Dockerfile
+++ b/dockerfiles/cli.Dockerfile
@@ -22,7 +22,7 @@ ARG BASE=akamai/base
 # BUILDER
 #########
 
-FROM golang:1.22.9-alpine3.19 as builder
+FROM golang:1.23.6-alpine3.21 as builder
 
 ARG CLI_REPOSITORY_URL=https://github.com/akamai/cli
 

--- a/dockerfiles/dns.Dockerfile
+++ b/dockerfiles/dns.Dockerfile
@@ -22,7 +22,7 @@ ARG BASE=akamai/base
 # BUILDER
 #########
 
-FROM golang:1.23.6-alpine3.21 as builder
+FROM golang:1.23.8-alpine3.21 as builder
 
 # this will only be used on architectures that upx doesn't use
 COPY files/upx-noop /usr/bin/upx

--- a/dockerfiles/dns.Dockerfile
+++ b/dockerfiles/dns.Dockerfile
@@ -22,7 +22,7 @@ ARG BASE=akamai/base
 # BUILDER
 #########
 
-FROM golang:1.22.9-alpine3.19 as builder
+FROM golang:1.23.6-alpine3.21 as builder
 
 # this will only be used on architectures that upx doesn't use
 COPY files/upx-noop /usr/bin/upx

--- a/dockerfiles/gtm.Dockerfile
+++ b/dockerfiles/gtm.Dockerfile
@@ -22,7 +22,7 @@ ARG BASE=akamai/base
 # BUILDER
 #########
 
-FROM golang:1.23.6-alpine3.21 as builder
+FROM golang:1.23.8-alpine3.21 as builder
 
 # this will only be used on architectures that upx doesn't use
 COPY files/upx-noop /usr/bin/upx

--- a/dockerfiles/gtm.Dockerfile
+++ b/dockerfiles/gtm.Dockerfile
@@ -22,7 +22,7 @@ ARG BASE=akamai/base
 # BUILDER
 #########
 
-FROM golang:1.22.9-alpine3.19 as builder
+FROM golang:1.23.6-alpine3.21 as builder
 
 # this will only be used on architectures that upx doesn't use
 COPY files/upx-noop /usr/bin/upx

--- a/dockerfiles/jsonnet.Dockerfile
+++ b/dockerfiles/jsonnet.Dockerfile
@@ -28,7 +28,7 @@ ARG BASE=akamai/base
 # image since it is likely that the user will want to render the
 # templates, not just generate them.
 
-FROM golang:1.23.6-alpine3.21 as jsonnet
+FROM golang:1.23.8-alpine3.21 as jsonnet
 
 # this will only be used on architectures that upx doesn't use
 COPY files/upx-noop /usr/bin/upx

--- a/dockerfiles/jsonnet.Dockerfile
+++ b/dockerfiles/jsonnet.Dockerfile
@@ -28,7 +28,7 @@ ARG BASE=akamai/base
 # image since it is likely that the user will want to render the
 # templates, not just generate them.
 
-FROM golang:1.22.9-alpine3.19 as jsonnet
+FROM golang:1.23.6-alpine3.21 as jsonnet
 
 # this will only be used on architectures that upx doesn't use
 COPY files/upx-noop /usr/bin/upx

--- a/dockerfiles/purge.Dockerfile
+++ b/dockerfiles/purge.Dockerfile
@@ -22,7 +22,7 @@ ARG BASE=akamai/base
 # BUILDER
 #########
 
-FROM golang:1.23.6-alpine3.21 as builder
+FROM golang:1.23.8-alpine3.21 as builder
 
 # this will only be used on architectures that upx doesn't use
 COPY files/upx-noop /usr/bin/upx

--- a/dockerfiles/purge.Dockerfile
+++ b/dockerfiles/purge.Dockerfile
@@ -22,7 +22,7 @@ ARG BASE=akamai/base
 # BUILDER
 #########
 
-FROM golang:1.22.9-alpine3.19 as builder
+FROM golang:1.23.6-alpine3.21 as builder
 
 # this will only be used on architectures that upx doesn't use
 COPY files/upx-noop /usr/bin/upx

--- a/dockerfiles/terraform-cli.Dockerfile
+++ b/dockerfiles/terraform-cli.Dockerfile
@@ -22,7 +22,7 @@ ARG BASE=akamai/base
 # BUILDER
 #########
 
-FROM golang:1.23.6-alpine3.21 as builder
+FROM golang:1.23.8-alpine3.21 as builder
 
 # this will only be used on architectures that upx doesn't use
 COPY files/upx-noop /usr/bin/upx

--- a/dockerfiles/terraform-cli.Dockerfile
+++ b/dockerfiles/terraform-cli.Dockerfile
@@ -22,7 +22,7 @@ ARG BASE=akamai/base
 # BUILDER
 #########
 
-FROM golang:1.22.9-alpine3.19 as builder
+FROM golang:1.23.6-alpine3.21 as builder
 
 # this will only be used on architectures that upx doesn't use
 COPY files/upx-noop /usr/bin/upx

--- a/dockerfiles/test-center.Dockerfile
+++ b/dockerfiles/test-center.Dockerfile
@@ -22,7 +22,7 @@ ARG BASE=akamai/base
 # BUILDER
 #########
 
-FROM golang:1.23.6-alpine3.21 as builder
+FROM golang:1.23.8-alpine3.21 as builder
 
 # this will only be used on architectures that upx doesn't use
 COPY files/upx-noop /usr/bin/upx

--- a/dockerfiles/test-center.Dockerfile
+++ b/dockerfiles/test-center.Dockerfile
@@ -22,7 +22,7 @@ ARG BASE=akamai/base
 # BUILDER
 #########
 
-FROM golang:1.22.9-alpine3.19 as builder
+FROM golang:1.23.6-alpine3.21 as builder
 
 # this will only be used on architectures that upx doesn't use
 COPY files/upx-noop /usr/bin/upx

--- a/files/terraform.tf
+++ b/files/terraform.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source = "akamai/akamai"
-      version = "7.0.0"
+      version = "7.1.0"
     }
 
     null = {


### PR DESCRIPTION
## v2.30.0 (2025-04-08)

* Upgraded akamai terraform provider to v7.1.0.
* Upgraded Go version to `1.23.8` and alpine to `3.21` for `dns`, `cli`, `gtm`, `jsonnet`, `purge`, `terraform-cli`, and `test-center` images.