### PR TITLE
Release/v2.32.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release notes
 
+## v2.32.0 (Aug 8, 2025)
+
+* Upgraded Akamai Terraform Provider to `v8.1.0`.
+
 ## v2.31.0 (May 29, 2025)
 
 * Upgraded Akamai Terraform Provider to `v8.0.0`.

--- a/files/terraform.tf
+++ b/files/terraform.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source = "akamai/akamai"
-      version = "8.0.0"
+      version = "8.1.0"
     }
 
     null = {

--- a/patches/cli-sandbox-datastore-location.patch
+++ b/patches/cli-sandbox-datastore-location.patch
@@ -1,11 +1,11 @@
 --- a/src/service/sandbox-client-manager.ts
 +++ b/src/service/sandbox-client-manager.ts
-@@ -28,7 +28,7 @@ const CLIENT_INSTALL_PATH = path.join(SANDBOX_CLI_HOME, CONNECTOR_FOLDER_NAME);
+@@ -34,7 +34,7 @@
+
  const JAR_FILE_PATH = path.join(CLIENT_INSTALL_PATH, path.join('/lib', JAR_FILE_NAME));
  const LOG_CONFIG_FILE = path.join(CLIENT_INSTALL_PATH, '/conf/logback.xml');
- 
 -const DATASTORE_FILE_PATH = path.join(SANDBOX_CLI_HOME + '.datastore');
 +const DATASTORE_FILE_PATH = path.join(SANDBOXES_DIR + '.datastore');
- 
- if (!fs.existsSync(SANDBOX_CLI_HOME)) {
-   fs.mkdirSync(SANDBOX_CLI_HOME);
+
+ if (!fs.existsSync(DOWNLOAD_DIR)) {
+   fs.mkdirSync(DOWNLOAD_DIR, { recursive: true });


### PR DESCRIPTION
# Release notes

## v2.32.0 (Aug 8, 2025)

* Upgraded Akamai Terraform Provider to `v8.1.0`.