### PR TITLE
Release/v2.33.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release notes
 
+## v2.33.0 (Sep 5, 2025)
+
+* Upgraded Akamai Terraform Provider to `v9.0.0`.
+
 ## v2.32.0 (Aug 8, 2025)
 
 * Upgraded Akamai Terraform Provider to `v8.1.0`.

--- a/files/terraform.tf
+++ b/files/terraform.tf
@@ -1,22 +1,22 @@
 terraform {
   required_providers {
     akamai = {
-      source = "akamai/akamai"
-      version = "8.1.0"
+      source  = "akamai/akamai"
+      version = "9.0.0"
     }
 
     null = {
-      source = "hashicorp/null"
+      source  = "hashicorp/null"
       version = "3.0.0"
     }
 
     local = {
-      source = "hashicorp/local"
+      source  = "hashicorp/local"
       version = "2.0.0"
     }
 
     jsonnet = {
-      source = "alxrem/jsonnet"
+      source  = "alxrem/jsonnet"
       version = "1.0.3"
     }
   }


### PR DESCRIPTION
## v2.33.0 (Sep 5, 2025)

* Upgraded Akamai Terraform Provider to `v9.0.0`.