### PR TITLE
Release/v2.33.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release notes
 
+## v2.33.1 (Sep 9, 2025)
+
+* Upgraded Akamai Terraform Provider to `v9.0.1`.
+
 ## v2.33.0 (Sep 5, 2025)
 
 * Upgraded Akamai Terraform Provider to `v9.0.0`.

--- a/files/terraform.tf
+++ b/files/terraform.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = "9.0.0"
+      version = "9.0.1"
     }
 
     null = {


### PR DESCRIPTION
## v2.33.1 (Sep 9, 2025)

* Upgraded Akamai Terraform Provider to `v9.0.1`.