### PR TITLE
Release/v2.33.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v2.33.6 (Apr 2, 2026)
 
+* Upgraded Akamai Terraform Provider to `v10.1.0`.
 * Upgraded Go to version `1.25.7` and Alpine to `3.23` for `cli`, `dns`, `gtm`, `jsonnet`, `purge`, `terraform-cli`, and `test-center` images.
 
 ## v2.33.5 (Feb 26, 2026)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Upgraded Akamai Terraform Provider to `v10.0.0`.
 * Fixed problems with `appsec` and `firewall` images.
+* Upgraded Go to version `1.25.7` and Alpine to `3.23` for `cli`, `dns`, `gtm`, `jsonnet`, `purge`, `terraform-cli`, and `test-center` images.
 
 ## v2.33.4 (Jan 22, 2026)
 

--- a/dockerfiles/cli.Dockerfile
+++ b/dockerfiles/cli.Dockerfile
@@ -8,7 +8,7 @@ ARG BASE=akamai/base
 # BUILDER
 #########
 
-FROM golang:1.24.11-alpine3.23 AS builder
+FROM golang:1.25.7-alpine3.23 AS builder
 
 ARG CLI_REPOSITORY_URL=https://github.com/akamai/cli
 

--- a/dockerfiles/dns.Dockerfile
+++ b/dockerfiles/dns.Dockerfile
@@ -8,7 +8,7 @@ ARG BASE=akamai/base
 # BUILDER
 #########
 
-FROM golang:1.24.11-alpine3.23 AS builder
+FROM golang:1.25.7-alpine3.23 AS builder
 
 # this will only be used on architectures that upx doesn't use
 COPY files/upx-noop /usr/bin/upx

--- a/dockerfiles/gtm.Dockerfile
+++ b/dockerfiles/gtm.Dockerfile
@@ -8,7 +8,7 @@ ARG BASE=akamai/base
 # BUILDER
 #########
 
-FROM golang:1.24.11-alpine3.23 AS builder
+FROM golang:1.25.7-alpine3.23 AS builder
 
 # this will only be used on architectures that upx doesn't use
 COPY files/upx-noop /usr/bin/upx

--- a/dockerfiles/jsonnet.Dockerfile
+++ b/dockerfiles/jsonnet.Dockerfile
@@ -14,7 +14,7 @@ ARG BASE=akamai/base
 # image since it is likely that the user will want to render the
 # templates, not just generate them.
 
-FROM golang:1.24.11-alpine3.23 AS jsonnet
+FROM golang:1.25.7-alpine3.23 AS jsonnet
 
 # this will only be used on architectures that upx doesn't use
 COPY files/upx-noop /usr/bin/upx

--- a/dockerfiles/purge.Dockerfile
+++ b/dockerfiles/purge.Dockerfile
@@ -8,7 +8,7 @@ ARG BASE=akamai/base
 # BUILDER
 #########
 
-FROM golang:1.24.11-alpine3.23 AS builder
+FROM golang:1.25.7-alpine3.23 AS builder
 
 # this will only be used on architectures that upx doesn't use
 COPY files/upx-noop /usr/bin/upx

--- a/dockerfiles/terraform-cli.Dockerfile
+++ b/dockerfiles/terraform-cli.Dockerfile
@@ -8,7 +8,7 @@ ARG BASE=akamai/base
 # BUILDER
 #########
 
-FROM golang:1.24.11-alpine3.23 AS builder
+FROM golang:1.25.7-alpine3.23 AS builder
 
 # this will only be used on architectures that upx doesn't use
 COPY files/upx-noop /usr/bin/upx

--- a/dockerfiles/test-center.Dockerfile
+++ b/dockerfiles/test-center.Dockerfile
@@ -8,7 +8,7 @@ ARG BASE=akamai/base
 # BUILDER
 #########
 
-FROM golang:1.24.11-alpine3.23 AS builder
+FROM golang:1.25.7-alpine3.23 AS builder
 
 # this will only be used on architectures that upx doesn't use
 COPY files/upx-noop /usr/bin/upx

--- a/files/terraform.tf
+++ b/files/terraform.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     akamai = {
       source  = "akamai/akamai"
-      version = "10.0.0"
+      version = "10.1.0"
     }
 
     null = {


### PR DESCRIPTION
## v2.33.6 (Apr 2, 2026)

* Upgraded Akamai Terraform Provider to `v10.1.0`.
* Upgraded Go to version `1.25.7` and Alpine to `3.23` for `cli`, `dns`, `gtm`, `jsonnet`, `purge`, `terraform-cli`, and `test-center` images.